### PR TITLE
remove-old-fix

### DIFF
--- a/modules/aws/bin/wazo_install_aws
+++ b/modules/aws/bin/wazo_install_aws
@@ -8,8 +8,7 @@ function configure_ha() {
 }
 
 function install_wazo() {
-    # NOTE: --allow-releaseinfo-change is only needed on debian < 10.10
-    apt-get update --allow-releaseinfo-change
+    apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install -yq ansible
     cd /usr/local/src
     wget https://github.com/wazo-platform/wazo-ansible/archive/master.tar.gz -O - | tar -xz


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to AWS install script behavior; main risk is `apt-get update` failing on older Debian releases that previously required the flag.
> 
> **Overview**
> Removes the deprecated Debian workaround in `wazo_install_aws` by changing `apt-get update --allow-releaseinfo-change` to a plain `apt-get update` during installation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b81eceaab9d4edb4329440b9bb3a1fc2b6933a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->