### PR TITLE
remove-redundant-vpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Enter the AWS module directory and init the terraform infrastructure:
 Create a terraform.tfvars with your values:
 
     subnet_id        = ""
-    vpc_id           = ""
     public_key_path  = "" # Path to your SSH public key file
     private_key_path = "" # Path to your SSH private key file
 

--- a/modules/aws/variables.tf
+++ b/modules/aws/variables.tf
@@ -30,10 +30,6 @@ variable "instance_type" {
   default     = "t3a.medium"
 }
 
-variable "vpc_id" {
-  description = "ID of the VPC to use."
-}
-
 variable "amazon_ami_name_filter" {
   description = "Filter to apply on names to retrieve AMI"
   type        = string

--- a/modules/aws/wazo.tf
+++ b/modules/aws/wazo.tf
@@ -187,7 +187,7 @@ resource "aws_security_group" "wazo" {
   count       = var.custom_security_group ? 0 : 1
   name        = local.sg_name
   description = "Wazo stack rules"
-  vpc_id      = var.vpc_id
+  vpc_id      = data.aws_subnet.this.vpc_id
 
   ingress {
     from_port = 22


### PR DESCRIPTION
why: can be extracted from subnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Terraform refactor that removes a redundant module input and derives `vpc_id` from the provided subnet. Main risk is a breaking change for existing users’ `terraform.tfvars`/module calls that still pass `vpc_id`.
> 
> **Overview**
> Simplifies the AWS Terraform module by **removing the `vpc_id` variable** and instead deriving the VPC from `data.aws_subnet.this.vpc_id` when creating the Wazo security group.
> 
> Updates the docs/examples (`README.md`) accordingly by dropping `vpc_id` from the required `terraform.tfvars` inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25220df6463515c3352a657d7afe0673ab39ac06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->